### PR TITLE
Link to release notes in navigation header

### DIFF
--- a/source/_templates/header.html
+++ b/source/_templates/header.html
@@ -30,6 +30,9 @@
             <div class="ods__documentation-header-nav-item">
                 <a href="https://academy.opendatasoft.com/{{ 'page/homepage/' if (language != 'fr') }}">Academy</a>
             </div>
+            <div class="ods__documentation-header-nav-item">
+                <a href="https://documentation-resources.opendatasoft.com/pages/release-notes/?headless=true">{{ gettext('Release notes') }}</a>
+            </div>
         </div>
     </div>
 


### PR DESCRIPTION
## Summary

This PR adds a link to the [release notes](https://documentation-resources.opendatasoft.com/pages/release-notes/?headless=true) in the navigation header, so that users can access this page when browsing the user guide.

Story details: https://app.clubhouse.io/opendatasoft/story/26719

## Changes

- Added a new link to the release notes in the navigation header.
- Created a "key", so that the "Release notes" link text gets translated.