### PR TITLE
Removed IE 11 from the supported browsers

### DIFF
--- a/source/faq.rst
+++ b/source/faq.rst
@@ -367,13 +367,7 @@ Frequently asked questions (FAQ)
     | |edge| **Edge**                  |                                                                        |
     |                                  | Latest version                                                         |
     +----------------------------------+------------------------------------------------------------------------+
-    | |iexplore| **Internet Explorer** |                                                                        |
-    |                                  | Version 11 *(not recommended)*                                         |
-    +----------------------------------+------------------------------------------------------------------------+
 
-    .. |iexplore| image:: browser-logos/ie_64x64.png
-        :alt: Internet Explorer
-        :width: 32
 
     .. |edge| image:: browser-logos/edge_64x64.png
         :alt: Edge


### PR DESCRIPTION
## Summary

This PR removes IE 11 from the supported browsers mentioned in the FAQ.

Story details: https://app.shortcut.com/opendatasoft/story/29517

## Changes

- Removed IE 11 from the supported browsers